### PR TITLE
Mark regex as fixed

### DIFF
--- a/R/extract_min_r_version.R
+++ b/R/extract_min_r_version.R
@@ -10,7 +10,7 @@ extract_min_r_version <- function(path = ".") {
 
   file.path(path, "DESCRIPTION") |>
     read.dcf("Depends") |>
-    strsplit(",") |>
+    strsplit(",", fixed = TRUE) |>
     unlist() |>
     trimws() |>
     (\(x) grep("R ", x, value = TRUE, fixed = TRUE))() |>


### PR DESCRIPTION
This PR introduces fixed substring expression, to improve compute times. This is most likely not going to affect the code much, but I got a warning in my dev environment so figured I'd simply go ahead and update it. The warning I received:

`This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "," with fixed = TRUE.lintr[fixed_regex_linter](https://lintr.r-lib.org/reference/fixed_regex_linter.html)`

This PR does not affect functionality.